### PR TITLE
update go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.8
 
 sudo: false
 


### PR DESCRIPTION
Current versions of Hugo will fail to install with `go get` using
golang 1.7.

I hope you're able to pull even if you're no longer using this setup, this repo helped me so much in setting up my own depoloyment.  